### PR TITLE
[FEATURE] Implement navigation ingestion for EPUB2

### DIFF
--- a/api/app/controllers/api/v1/text_sections_controller.rb
+++ b/api/app/controllers/api/v1/text_sections_controller.rb
@@ -15,7 +15,6 @@ module Api
       def set_section
         @text_section = TextSection.find(params[:id])
       end
-
     end
   end
 end

--- a/api/app/models/category.rb
+++ b/api/app/models/category.rb
@@ -1,6 +1,5 @@
 # Used to group texts and resources in a project
 class Category < ActiveRecord::Base
-
   ROLE_TEXT = "text"
   ROLE_RESOURCE = "resource"
 
@@ -8,11 +7,9 @@ class Category < ActiveRecord::Base
   has_many :texts
 
   validates :role,
-            :inclusion  => { :in => [ROLE_TEXT, ROLE_RESOURCE],
-                             :message    => "%{value} is not a valid category role" }
+            inclusion: { in: [ROLE_TEXT, ROLE_RESOURCE],
+                         message: "%{value} is not a valid category role" }
 
   scope :for_text, -> { where(role: ROLE_TEXT) }
   scope :for_resource, -> { where(role: ROLE_RESOURCE) }
-
-
 end

--- a/api/app/models/project.rb
+++ b/api/app/models/project.rb
@@ -1,8 +1,8 @@
 # The project model is the primary unit of Manifold.
 class Project < ActiveRecord::Base
   has_many :texts
-  has_many :text_categories, -> { for_text }, :class_name => "Category"
-  has_many :resource_categories, -> { for_resource }, :class_name => "Category"
+  has_many :text_categories, -> { for_text }, class_name: "Category"
+  has_many :resource_categories, -> { for_resource }, class_name: "Category"
 
   include Collaborative
 

--- a/api/app/serializers/text_serializer.rb
+++ b/api/app/serializers/text_serializer.rb
@@ -7,5 +7,3 @@ class TextSerializer < TextPartialSerializer
   has_many :text_sections, serializer: TextSectionPartialSerializer
   has_one :toc_section, serializer: TextSectionSerializer
 end
-
-

--- a/api/app/services/html_serializer.rb
+++ b/api/app/services/html_serializer.rb
@@ -54,6 +54,7 @@ class HtmlSerializer
     end
     representation[:children] = representation[:children].reject do |child|
       child[:delete] == true
+
     end
   end
 

--- a/api/app/services/ingestor/strategy/epub/builder.rb
+++ b/api/app/services/ingestor/strategy/epub/builder.rb
@@ -167,7 +167,7 @@ module Ingestor
           return unless d.present?
           text.publication_date = d
           debug "services.ingestor.strategy.ePUB.log.set_date",
-               date: text.publication_date
+                date: text.publication_date
         end
 
         def update_rights!(text)

--- a/api/app/services/ingestor/strategy/epub/builder.rb
+++ b/api/app/services/ingestor/strategy/epub/builder.rb
@@ -102,7 +102,7 @@ module Ingestor
                                          text, text.text_sections)
           text.text_sections.replace(text_sections.reject(&:nil?))
           text_sections.each do |text_section|
-            if !text_section.valid?
+            unless text_section.valid?
               Helper::Log.log_model_errors(text_section, @logger)
             end
           end

--- a/api/app/services/ingestor/strategy/epub/creator/text_sections.rb
+++ b/api/app/services/ingestor/strategy/epub/creator/text_sections.rb
@@ -28,9 +28,9 @@ module Ingestor
 
           def log(node_inspector, section)
             debug "services.ingestor.strategy.ePUB.log.section_name",
-                 id: node_inspector.idref, name: section.name
+                  id: node_inspector.idref, name: section.name
             debug "services.ingestor.strategy.ePUB.log.section_kind",
-                 id: node_inspector.idref, kind: section.kind
+                  id: node_inspector.idref, kind: section.kind
           end
 
           def inspectors(node, epub_inspector)

--- a/api/app/services/ingestor/strategy/epub/inspector/epub.rb
+++ b/api/app/services/ingestor/strategy/epub/inspector/epub.rb
@@ -162,7 +162,8 @@ module Ingestor
 
           def manifest_nav_item
             if v2?
-              manifest_node.at_xpath('//*[@id="ncx"]')
+              toc_id = spine_node.attribute("toc")
+              manifest_node.at_xpath('//*[@id="' + toc_id + '"]')
             elsif v3?
               manifest_node.at_xpath(('//*[contains(@properties, "nav")]'))
             end
@@ -197,12 +198,16 @@ module Ingestor
             end
           end
 
-          def nav_xml
+          def nav_xml_with_ns
             node = manifest_nav_item
             return unless node
             local_path = node.attribute("href")
-            xml = Nokogiri::XML(get_rendition_source(local_path))
-            xml.remove_namespaces!
+            Nokogiri::XML(get_rendition_source(local_path))
+          end
+          memoize :nav_xml_with_ns
+
+          def nav_xml
+            nav_xml_with_ns.remove_namespaces!
           end
           memoize :nav_xml
 

--- a/api/app/services/ingestor/strategy/epub/inspector/epub.rb
+++ b/api/app/services/ingestor/strategy/epub/inspector/epub.rb
@@ -115,6 +115,11 @@ module Ingestor
           end
           memoize :spine_node
 
+          # V2 only
+          def guide_node
+            rendition_xml.xpath("//xmlns:package/xmlns:guide")
+          end
+
           def title_nodes
             metadata_node.xpath("//dc:title", "dc" => dc)
           end
@@ -156,10 +161,11 @@ module Ingestor
           memoize :manifest_item_nodes
 
           def manifest_nav_item
-            v2_path = '//*[@id="ncx"]'
-            return manifest_node.xpath(v2_path).first if v2?
-            v3_path = '//*[contains(@properties, "nav")]'
-            return manifest_node.xpath((v3_path)).first if v3?
+            if v2?
+              manifest_node.at_xpath('//*[@id="ncx"]')
+            elsif v3?
+              manifest_node.at_xpath(('//*[contains(@properties, "nav")]'))
+            end
           end
           memoize :manifest_nav_item
 

--- a/api/app/services/ingestor/strategy/epub/inspector/toc.rb
+++ b/api/app/services/ingestor/strategy/epub/inspector/toc.rb
@@ -42,6 +42,16 @@ module Ingestor
             }
           end
 
+          def toc_structure
+            nodes = toc_node.xpath(selector_toc_node)
+            toc_nodes_to_structure(nodes)
+          end
+
+          def page_list_structure
+            nodes = page_list_node.xpath(selector_page_list_node)
+            page_list_nodes_to_structure(nodes)
+          end
+
           private
 
           def structure_titles
@@ -77,16 +87,6 @@ module Ingestor
             text = header_text_for_node(page_list_node)
             debug "services.ingestor.strategy.ePUB.log.page_list_nav_title", text: text
             text
-          end
-
-          def toc_structure
-            nodes = toc_node.xpath(selector_toc_node)
-            toc_nodes_to_structure(nodes)
-          end
-
-          def page_list_structure
-            nodes = page_list_node.xpath(selector_page_list_node)
-            page_list_nodes_to_structure(nodes)
           end
 
           def make_structure_item(raw_label, raw_path = nil)

--- a/api/app/services/ingestor/strategy/epub/inspector/toc/v2.rb
+++ b/api/app/services/ingestor/strategy/epub/inspector/toc/v2.rb
@@ -6,6 +6,13 @@ module Ingestor
           # This module contributes object methods to the TOC inspector for EPUB2
           # documents.
           module V2
+            def landmarks_structure
+              # rubocop: disable Metrics/LineLength
+              landmarks_nodes_to_structure(@epub_inspector.guide_node.xpath("xmlns:reference"))
+            end
+
+            private
+
             def selector_toc_root_node
               "//navMap"
             end
@@ -63,12 +70,6 @@ module Ingestor
 
             def page_list_nodes_to_structure(nodes)
               nodes_to_structure(nodes)
-            end
-
-
-            def landmarks_structure
-              # rubocop: disable Metrics/LineLength
-              landmarks_nodes_to_structure(@epub_inspector.guide_node.xpath("xmlns:reference"))
             end
 
             # Landmarks are different than the other two

--- a/api/app/services/ingestor/strategy/epub/inspector/toc/v2.rb
+++ b/api/app/services/ingestor/strategy/epub/inspector/toc/v2.rb
@@ -1,0 +1,91 @@
+module Ingestor
+  module Strategy
+    module EPUB
+      module Inspector
+        class TOC
+          # This module contributes object methods to the TOC inspector for EPUB2
+          # documents.
+          module V2
+            def selector_toc_root_node
+              "//navMap"
+            end
+
+            def selector_toc_node
+              "navPoint"
+            end
+
+            def selector_page_list_root_node
+              "//pageList"
+            end
+
+            def selector_page_list_node
+              "pageTarget"
+            end
+
+            def selector_header_node
+              "//navLabel/text/text()"
+            end
+
+            def selector_toc_label
+              "//*[starts-with(@src,'%s')]/../navLabel/text/text()"
+            end
+
+            # We're relying on the guide element in the opf file; there's no title for
+            # this
+            def landmarks_title
+              ""
+            end
+
+            # rubocop: disable Metrics/AbcSize
+            # rubocop: disable Metrics/MethodLength
+            def nodes_to_structure(nodes)
+              items = []
+              if nodes.count
+                nodes.each do |node|
+                  item = {}
+                  if node.at_xpath("content")
+                    label = node.at_xpath("navLabel/text/text()").text
+                    href = node.at_css("content").attribute("src").value
+                    item = make_structure_item(label, href)
+                    if node.at_xpath("navPoint")
+                      item[:children] = toc_nodes_to_structure(node.xpath("navPoint"))
+                    end
+                  end
+                  items.push item unless item.empty?
+                end
+              end
+              items
+            end
+
+            def toc_nodes_to_structure(nodes)
+              nodes_to_structure(nodes)
+            end
+
+            def page_list_nodes_to_structure(nodes)
+              nodes_to_structure(nodes)
+            end
+
+
+            def landmarks_structure
+              # rubocop: disable Metrics/LineLength
+              landmarks_nodes_to_structure(@epub_inspector.guide_node.xpath("xmlns:reference"))
+            end
+
+            # Landmarks are different than the other two
+            def landmarks_nodes_to_structure(nodes)
+              items = []
+              if nodes.count
+                nodes.each do |node|
+                  label = node.at_xpath("@title").value
+                  href = node.at_xpath("@href").value
+                  items.push make_structure_item(label, href)
+                end
+              end
+              items
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/api/app/services/ingestor/strategy/epub/inspector/toc/v2.rb
+++ b/api/app/services/ingestor/strategy/epub/inspector/toc/v2.rb
@@ -7,11 +7,14 @@ module Ingestor
           # documents.
           module V2
             def landmarks_structure
-              # rubocop: disable Metrics/LineLength
-              landmarks_nodes_to_structure(@epub_inspector.guide_node.xpath("xmlns:reference"))
+              landmarks_nodes_to_structure(guide_node_references)
             end
 
             private
+
+            def guide_node_references
+              @epub_inspector.guide_node.xpath("xmlns:reference")
+            end
 
             def selector_toc_root_node
               "//navMap"

--- a/api/app/services/ingestor/strategy/epub/inspector/toc/v3.rb
+++ b/api/app/services/ingestor/strategy/epub/inspector/toc/v3.rb
@@ -1,0 +1,97 @@
+module Ingestor
+  module Strategy
+    module EPUB
+      module Inspector
+        class TOC
+          # This module contributes object methods to the TOC inspector for EPUB3
+          # documents.
+          module V3
+            def selector_toc_root_node
+              "//nav[@type='toc']/ol"
+            end
+
+            def selector_toc_node
+              "li"
+            end
+
+            def selector_page_list_root_node
+              "//nav[@type='page-list']/ol"
+            end
+
+            def selector_page_list_node
+              "li"
+            end
+
+            def selector_landmark_root_node
+              "//nav[@type='landmarks']/ol"
+            end
+
+            def selector_landmark_node
+              "li"
+            end
+
+            def selector_toc_label
+              "//*[@href='%s']"
+            end
+
+            def selector_header_node
+              "//*[self::h1 or self::h2 or self::h3 or self::h4 or self::h5 or self::h6]"
+            end
+
+            def landmarks_title
+              text = header_text_for_node(landmarks_node)
+              debug "services.ingestor.strategy.ePUB.log.landmark_nav_title", text: text
+              text
+            end
+
+            def landmarks_structure
+              nodes = landmarks_node.xpath(selector_landmark_node)
+              landmarks_nodes_to_structure(nodes)
+            end
+
+            def landmarks_node
+              @nav_xml.xpath(selector_landmark_root_node)
+            end
+
+            # rubocop: disable Metrics/MethodLength
+            # rubocop: disable Metrics/AbcSize
+            # @todo: Reduce method length, reduce complexity
+            def nodes_to_structure(nodes)
+              items = []
+              if nodes.count
+                nodes.each do |node|
+                  if node.at_xpath("a")
+                    label = node.at_css("a").text
+                    href = node.at_css("a").attribute("href").value
+                  elsif node.at_xpath("span")
+                    label = node.at_css("span").text.strip
+                    href = nil
+                  end
+                  item = make_structure_item(label, href)
+
+                  if node.at_xpath("ol/li")
+                    item[:children] = nodes_to_structure(node.xpath("ol/li"))
+                  end
+                  items.push item unless item.empty?
+                end
+              end
+              items
+            end
+
+            def toc_nodes_to_structure(nodes)
+              nodes_to_structure(nodes)
+            end
+
+            def page_list_nodes_to_structure(nodes)
+              nodes_to_structure(nodes)
+            end
+
+            def landmarks_nodes_to_structure(nodes)
+              nodes_to_structure(nodes)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/api/app/services/ingestor/strategy/epub/inspector/toc/v3.rb
+++ b/api/app/services/ingestor/strategy/epub/inspector/toc/v3.rb
@@ -6,6 +6,13 @@ module Ingestor
           # This module contributes object methods to the TOC inspector for EPUB3
           # documents.
           module V3
+            def landmarks_structure
+              nodes = landmarks_node.xpath(selector_landmark_node)
+              landmarks_nodes_to_structure(nodes)
+            end
+
+            private
+
             def selector_toc_root_node
               "//nav[@type='toc']/ol"
             end
@@ -42,11 +49,6 @@ module Ingestor
               text = header_text_for_node(landmarks_node)
               debug "services.ingestor.strategy.ePUB.log.landmark_nav_title", text: text
               text
-            end
-
-            def landmarks_structure
-              nodes = landmarks_node.xpath(selector_landmark_node)
-              landmarks_nodes_to_structure(nodes)
             end
 
             def landmarks_node

--- a/api/app/services/ingestor/strategy/epub/strategy.rb
+++ b/api/app/services/ingestor/strategy/epub/strategy.rb
@@ -37,7 +37,8 @@ module Ingestor
         end
 
         def ingest
-          info "services.ingestor.strategy.ePUB.log.version", version: @inspector.epub_version
+          info "services.ingestor.strategy.ePUB.log.version",
+               version: @inspector.epub_version
           text = @ingestion.text
           Builder.new(@inspector, @logger).build(text)
           text

--- a/api/app/services/ingestor/strategy/epub/strategy.rb
+++ b/api/app/services/ingestor/strategy/epub/strategy.rb
@@ -37,6 +37,7 @@ module Ingestor
         end
 
         def ingest
+          info "services.ingestor.strategy.ePUB.log.version", version: @inspector.epub_version
           text = @ingestion.text
           Builder.new(@inspector, @logger).build(text)
           text

--- a/api/config/locales/services/ingestor/en.yml
+++ b/api/config/locales/services/ingestor/en.yml
@@ -4,7 +4,7 @@ en:
       logging:
         ingestion_start: 'Ingesting %{name}!'
         text_found: 'Found existing Text model with ID of %{id}'
-        text_found: 'No existing text model found for source ID %{id}'
+        text_not_found: 'No existing text model found for source ID %{id}'
         using_strategy: 'Using strategy %{strategy}'
         ingestion_end: '%{name} ingested!'
       failures:

--- a/api/config/locales/services/ingestor/strategy/epub/en.yml
+++ b/api/config/locales/services/ingestor/strategy/epub/en.yml
@@ -4,6 +4,7 @@ en:
       strategy:
         ePUB:
           log:
+            version: 'EPUB version is %{version}'
             update_structures: 'Updating text structures. [id %{id}]'
             transform_ts: 'Transforming text section "%{name}" body.'
             transforming_ts: 'Transforming text sections'

--- a/api/lib/tasks/ingest.rake
+++ b/api/lib/tasks/ingest.rake
@@ -7,7 +7,7 @@ namespace :ingest do
   desc "Ingests EPUB3 files in /epubs into Manifold"
   task :texts, [:log_level] => :environment do |_t, _args|
     epubs = Dir["../texts/*"]
-    epubs.reject{ |epub| epub.start_with?(".") }.each do |epub|
+    epubs.reject { |epub| epub.start_with?(".") }.each do |epub|
       ingest(epub, :debug)
     end
   end

--- a/api/spec/data/epubs/fragments/v2_guide_node.xml
+++ b/api/spec/data/epubs/fragments/v2_guide_node.xml
@@ -1,0 +1,12 @@
+<package version="2.0" unique-identifier="uid" xmlns="http://www.idpf.org/2007/opf">
+    <opf:metadata xmlns:dc="http://purl.org/dc/elements/1.1/"
+                  xmlns:dcterms="http://purl.org/dc/terms/"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xmlns:opf="http://www.idpf.org/2007/opf">
+    <guide>
+        <reference type="copyright-page" title="Copyright" href="ump-feeley1-0004.xhtml#cip"/>
+        <reference type="text" title="Title Page" href="ump-feeley1-0003.xhtml#bk"/>
+        <reference type="toc" title="Table of Contents" href="ump-feeley1-0005.xhtml#toc"/>
+        <reference type="cover" title="Cover" href="ump-feeley1-0001.xhtml#cvi"/>
+    </guide>
+</package>

--- a/api/spec/data/epubs/fragments/v2_ncx_navmap_node.xml
+++ b/api/spec/data/epubs/fragments/v2_ncx_navmap_node.xml
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1" xml:lang="en-US">
+    <navMap>
+        <navPoint id="cvi" playOrder="1">
+            <navLabel>
+                <text>Cover</text>
+            </navLabel>
+            <content src="ump-feeley1-0001.xhtml#cvi"/>
+        </navPoint>
+        <navPoint id="bk" playOrder="2">
+            <navLabel>
+                <text>Title Page</text>
+            </navLabel>
+            <content src="ump-feeley1-0003.xhtml#bk"/>
+        </navPoint>
+        <navPoint id="cip" playOrder="3">
+            <navLabel>
+                <text>Copyright Page</text>
+            </navLabel>
+            <content src="ump-feeley1-0004.xhtml#cip"/>
+        </navPoint>
+        <navPoint id="toc" playOrder="4">
+            <navLabel>
+                <text>Contents</text>
+            </navLabel>
+            <content src="ump-feeley1-0005.xhtml#toc"/>
+        </navPoint>
+        <navPoint id="acknow" playOrder="5">
+            <navLabel>
+                <text>Acknowledgments</text>
+            </navLabel>
+            <content src="ump-feeley1-0006.xhtml#acknow"/>
+        </navPoint>
+        <navPoint id="intro" playOrder="6">
+            <navLabel>
+                <text>Introduction</text>
+            </navLabel>
+            <content src="ump-feeley1-0007.xhtml#intro"/>
+        </navPoint>
+        <navPoint id="pt01" playOrder="7">
+            <navLabel>
+                <text>Part I. Intermediality and New Media Economies</text>
+            </navLabel>
+            <content src="ump-feeley1-0008.xhtml#pt01"/>
+            <navPoint id="ch01" playOrder="8">
+                <navLabel>
+                    <text>1. Scan Lines: How Cyborgs Feel</text>
+                </navLabel>
+                <content src="ump-feeley1-0009.xhtml#ch01"/>
+            </navPoint>
+            <navPoint id="ch02" playOrder="9">
+                <navLabel>
+                    <text>2. What Is Estranged in Science Fiction Animation?</text>
+                </navLabel>
+                <content src="ump-feeley1-0010.xhtml#ch02"/>
+            </navPoint>
+            <navPoint id="ch03" playOrder="10">
+                <navLabel>
+                    <text>3. Famous for Fifteen Minutes: Permutations of Science Fiction Short Film</text>
+                </navLabel>
+                <content src="ump-feeley1-0011.xhtml#ch03"/>
+            </navPoint>
+            <navPoint id="ch04" playOrder="11">
+                <navLabel>
+                    <text>4. Forms of Journey and Archive: Remaking Science Fiction in Contemporary Artist-Filmmakers’
+                        Projects
+                    </text>
+                </navLabel>
+                <content src="ump-feeley1-0012.xhtml#ch04"/>
+            </navPoint>
+        </navPoint>
+        <navPoint id="pt02" playOrder="12">
+            <navLabel>
+                <text>Part II. Traveling Science Fiction: Translation, Adaptation, and Interpretation</text>
+            </navLabel>
+            <content src="ump-feeley1-0013.xhtml#pt02"/>
+            <navPoint id="ch05" playOrder="13">
+                <navLabel>
+                    <text>5. Media Heterotopias and Science Fiction: Transnational Workflows and Transgalactic Spaces in
+                        Digitally Composited Ecosystems
+                    </text>
+                </navLabel>
+                <content src="ump-feeley1-0014.xhtml#ch05"/>
+            </navPoint>
+            <navPoint id="ch06" playOrder="14">
+                <navLabel>
+                    <text>6. F. P. 1 and the Language of a Global Science Fiction Cinema</text>
+                </navLabel>
+                <content src="ump-feeley1-0015.xhtml#ch06"/>
+            </navPoint>
+            <navPoint id="ch07" playOrder="15">
+                <navLabel>
+                    <text>7. Enthiran, the Robot: Sujatha, Science Fiction, and Tamil Cinema</text>
+                </navLabel>
+                <content src="ump-feeley1-0016.xhtml#ch07"/>
+            </navPoint>
+        </navPoint>
+        <navPoint id="pt03" playOrder="16">
+            <navLabel>
+                <text>Part III. Spatial and Temporal Alternative Modernities in the Global South</text>
+            </navLabel>
+            <content src="ump-feeley1-0017.xhtml#pt03"/>
+            <navPoint id="ch08" playOrder="17">
+                <navLabel>
+                    <text>8. Polytemporality in Argentine Science Fiction Film: A Critique of the Homogeneous Time of
+                        Historicism and Modernity
+                    </text>
+                </navLabel>
+                <content src="ump-feeley1-0018.xhtml#ch08"/>
+            </navPoint>
+            <navPoint id="ch09" playOrder="18">
+                <navLabel>
+                    <text>9. Virtual Immigrants: Transfigured Bodies and Transnational Spaces in Science Fiction
+                        Cinema
+                    </text>
+                </navLabel>
+                <content src="ump-feeley1-0019.xhtml#ch09"/>
+            </navPoint>
+            <navPoint id="ch10" playOrder="19">
+                <navLabel>
+                    <text>10. Walking Dead in Havana: Juan of the Dead and the Zombie Film Genre</text>
+                </navLabel>
+                <content src="ump-feeley1-0020.xhtml#ch10"/>
+            </navPoint>
+        </navPoint>
+        <navPoint id="pt04" playOrder="20">
+            <navLabel>
+                <text>Part IV. Techno-Capitalism and Techno-Desires: The Gendered Affect of Post-Cyborgs</text>
+            </navLabel>
+            <content src="ump-feeley1-0021.xhtml#pt04"/>
+            <navPoint id="ch11" playOrder="21">
+                <navLabel>
+                    <text>11. Who Does the Feeling When There’s No Body There? Critical Feminism Meets Cyborg Affect in
+                        Oshii Mamoru’s Innocence
+                    </text>
+                </navLabel>
+                <content src="ump-feeley1-0022.xhtml#ch11"/>
+            </navPoint>
+            <navPoint id="ch12" playOrder="22">
+                <navLabel>
+                    <text>12. The Invention of Romance: Park Chan-wook’s I’m a Cyborg, but That’s OK</text>
+                </navLabel>
+                <content src="ump-feeley1-0023.xhtml#ch12"/>
+            </navPoint>
+            <navPoint id="ch13" playOrder="23">
+                <navLabel>
+                    <text>13. A Disenchanted Fantastic: The Pathos of Objects in Hirokazu Kore-eda’s Air Doll</text>
+                </navLabel>
+                <content src="ump-feeley1-0024.xhtml#ch13"/>
+            </navPoint>
+        </navPoint>
+        <navPoint id="pt05" playOrder="24">
+            <navLabel>
+                <text>Part V. National, International, Intergalactic: Socialist and Postsocialist Science Fiction
+                    Cinema
+                </text>
+            </navLabel>
+            <content src="ump-feeley1-0025.xhtml#pt05"/>
+            <navPoint id="ch14" playOrder="25">
+                <navLabel>
+                    <text>14. Alien Commodities in Soviet Science Fiction Cinema: Aelita, Solaris, and Kin-dza-dza!
+                    </text>
+                </navLabel>
+                <content src="ump-feeley1-0026.xhtml#ch14"/>
+            </navPoint>
+            <navPoint id="ch15" playOrder="26">
+                <navLabel>
+                    <text>15. Parodies of Realism at the Margins of Science Fiction: Jang Jun-hwan’s Save the Green
+                        Planet and Sin Sang-ok’s Pulgasari
+                    </text>
+                </navLabel>
+                <content src="ump-feeley1-0027.xhtml#ch15"/>
+            </navPoint>
+            <navPoint id="ch16" playOrder="27">
+                <navLabel>
+                    <text>16. Media and Messages: Blurred Visions of Nation and Science in Death Ray on a Coral Island
+                    </text>
+                </navLabel>
+                <content src="ump-feeley1-0028.xhtml#ch16"/>
+            </navPoint>
+        </navPoint>
+        <navPoint id="ch17" playOrder="28">
+            <navLabel>
+                <text>Select Filmography</text>
+            </navLabel>
+            <content src="ump-feeley1-0029.xhtml#ch17"/>
+        </navPoint>
+        <navPoint id="contrib" playOrder="29">
+            <navLabel>
+                <text>Contributors</text>
+            </navLabel>
+            <content src="ump-feeley1-0030.xhtml#contrib"/>
+        </navPoint>
+        <navPoint id="index" playOrder="30">
+            <navLabel>
+                <text>Index</text>
+            </navLabel>
+            <content src="ump-feeley1-0031.xhtml#index"/>
+        </navPoint>
+    </navMap>
+</ncx>

--- a/api/spec/data/epubs/fragments/v2_ncx_pagelist_node.xml
+++ b/api/spec/data/epubs/fragments/v2_ncx_pagelist_node.xml
@@ -1,0 +1,17 @@
+<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1" xml:lang="en-US">
+    /* Borrowed from: http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm */
+    <pageList>
+        <pageTarget id="p1" type="normal" value="1">
+            <navLabel>
+                <text>1</text>
+            </navLabel>
+            <content src="content.html#p1"/>
+        </pageTarget>
+        <pageTarget id="p2" type="normal" value="2">
+            <navLabel>
+                <text>2</text>
+            </navLabel>
+            <content src="content.html#p2"/>
+        </pageTarget>
+    </pageList>
+</ncx>

--- a/api/spec/services/ingestor/strategy/epub/inspector/toc_spec.rb
+++ b/api/spec/services/ingestor/strategy/epub/inspector/toc_spec.rb
@@ -1,0 +1,132 @@
+require "rails_helper"
+
+RSpec.describe Ingestor::Strategy::EPUB::Inspector::TOC do
+
+  EpubInspector = Ingestor::Strategy::EPUB::Inspector::EPUB
+  TocInspector = Ingestor::Strategy::EPUB::Inspector::TOC
+
+  context "with an EPUB2" do
+
+    let(:version) { '2.0' }
+    let(:opf_content) do
+      xml = '
+      <package version="2.0" unique-identifier="uid" xmlns="http://www.idpf.org/2007/opf">
+        <guide>
+          <reference type="copyright-page" title="Copyright" href="ump-feeley1-0004.xhtml#cip"/>
+          <reference type="text" title="Title Page" href="ump-feeley1-0003.xhtml#bk"/>
+        </guide>
+      </package>
+      '
+      Nokogiri::XML(xml)
+    end
+    let(:ncx_content) do
+      '<?xml version="1.0" encoding="UTF-8"?>
+        <ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1" xml:lang="en-US">
+          <navMap>
+            <navPoint id="cvi" playOrder="1">
+              <navLabel>
+                <text>Cover</text>
+              </navLabel>
+              <content src="ump-feeley1-0001.xhtml#cvi"/>
+            </navPoint>
+            <navPoint id="cip" playOrder="3">
+              <navLabel>
+                <text>Copyright Page</text>
+              </navLabel>
+              <content src="ump-feeley1-0004.xhtml#cip"/>
+            </navPoint>
+          </navMap>
+          <pageList>
+            <pageTarget id="page3" type="normal" value="3" playOrder="59">
+              <navLabel>
+                <text>3</text>
+              </navLabel>
+              <content src="intro.xhtml#page3"/>
+            </pageTarget>
+            <pageTarget id="page4" type="normal" value="4" playOrder="60">
+              <navLabel>
+                <text>4</text>
+              </navLabel>
+              <content src="intro.xhtml#page4"/>
+            </pageTarget>
+          </pageList>
+        </ncx>
+      '
+    end
+
+    let(:logger) { Logger.new("/dev/null") }
+    let(:path) { "some/dumb/path" }
+    let(:epub_inspector) do
+      inspector = EpubInspector.new(path, logger)
+      allow(inspector).to receive(:v2?).and_return(true)
+      allow(inspector).to receive(:nav_xml_with_ns).and_return(Nokogiri::XML(ncx_content))
+      allow(inspector).to receive(:nav_path).and_return('some/path')
+      inspector
+    end
+    let(:toc_inspector) do
+      toc_inspector = TocInspector.new(epub_inspector)
+      allow(toc_inspector).to receive(:guide_node_references).and_return(opf_content.xpath("//xmlns:reference"))
+      toc_inspector
+    end
+    let(:text_structure) do
+      toc_inspector.text_structure
+    end
+    let(:toc_structure) do
+      text_structure[:toc]
+    end
+    let(:page_list_structure) do
+      text_structure[:page_list]
+    end
+    let(:landmarks_structure) do
+      text_structure[:landmarks]
+    end
+
+    it "returns an object" do
+      expect(text_structure).to_not be_nil
+    end
+
+    it "returns the correct number of text structure items" do
+      expect(text_structure.length).to eq(4)
+    end
+
+    it "parses the correct number of TOC items" do
+      expect(toc_structure.length).to eq(2)
+    end
+
+    it "creates a TOC structure item with the correct values" do
+      last_toc_item = toc_structure.last
+      expect(last_toc_item).to eq({
+                                    label: "Copyright Page",
+                                    anchor: "cip",
+                                    source_path: "some/ump-feeley1-0004.xhtml"
+                                  })
+    end
+
+    it "parses the correct number of page list items" do
+      expect(page_list_structure.length).to eq(2)
+    end
+
+    it "creates a page list structure item with the correct values" do
+      last_page_list_item = page_list_structure.last
+      expect(last_page_list_item).to eq({
+                                          label: "4",
+                                          anchor: "page4",
+                                          source_path: "some/intro.xhtml"
+                                        })
+    end
+
+    it "parses the correct number of guide items" do
+      expect(landmarks_structure.length).to eq(2)
+    end
+
+    it "creates a guide structure item with the correct values" do
+      last_landmarks_item = landmarks_structure.last
+      expect(last_landmarks_item).to eq({
+                                          label: "Title Page",
+                                          anchor: "bk",
+                                          source_path: "some/ump-feeley1-0003.xhtml"
+                                        })
+    end
+  end
+end
+


### PR DESCRIPTION
This includes further refactoring of the EPUB3 / EPUB2
split into distinct modules within the EPUB::Inspector::TOC
namespace. Because the gap between the two versions widened
considerably, this split became essential to avoiding
redundant conditional logic.
