### PR TITLE
[F] Add static loading indicator component

### DIFF
--- a/client/src/components/shared/LoadingBar.js
+++ b/client/src/components/shared/LoadingBar.js
@@ -1,0 +1,23 @@
+import React, { Component } from 'react';
+
+export default class LoadingBar extends Component {
+  getInitialState = () => {
+    return {
+      status: 0
+    };
+  };
+
+  bindKey = () => {
+
+  };
+
+  render = () => {
+    this.bindKey();
+
+    return (
+        <div className="loading-bar">
+          <div className="progress"></div>
+        </div>
+    );
+  };
+}

--- a/client/src/components/shared/index.js
+++ b/client/src/components/shared/index.js
@@ -3,12 +3,14 @@ import UIPanel from './UIPanel';
 import UserMenuBody from './UserMenuBody';
 import UserMenuButton from './UserMenuButton';
 import LoginOverlay from './LoginOverlay';
+import LoadingBar from './LoadingBar';
 
 export {
   BodyClass,
   UIPanel,
   UserMenuBody,
   UserMenuButton,
-  LoginOverlay
+  LoginOverlay,
+  LoadingBar
 };
 

--- a/client/src/containers/frontend/Frontend.js
+++ b/client/src/containers/frontend/Frontend.js
@@ -3,7 +3,7 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import DocumentMeta from 'react-document-meta';
 import config from '../../config';
-import { BodyClass, LoginOverlay } from '../../components/shared';
+import { BodyClass, LoginOverlay, LoadingBar } from '../../components/shared';
 import { Header, Footer } from '../../components/frontend';
 import { startLogout } from '../../actions/shared/authentication';
 import { visibilityToggle, visibilityHide, visibilityShow, panelToggle, panelHide } from '../../actions/shared/ui/visibility';
@@ -48,8 +48,9 @@ export default class Frontend extends Component {
   render() {
     return (
       <BodyClass className={'browse'}>
-        <div onClick={this.handleClick}>
+        <div>
           <DocumentMeta {...config.app}/>
+          <LoadingBar />
           <Header
               visibility={this.props.visibility }
               location={this.props.location}

--- a/client/src/containers/reader/Reader.js
+++ b/client/src/containers/reader/Reader.js
@@ -3,7 +3,7 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import DocumentMeta from 'react-document-meta';
 import config from '../../config';
-import { BodyClass, LoginOverlay } from '../../components/shared';
+import { BodyClass, LoginOverlay, LoadingBar } from '../../components/shared';
 import { Header } from '../../components/reader';
 import connectData from '../../decorators/connectData';
 import { fetchOneText } from '../../actions/shared/collections';
@@ -54,6 +54,7 @@ class Reader extends Component {
     text: PropTypes.object,
     visibility: PropTypes.object,
     appearance: PropTypes.object,
+    stylesheets: PropTypes.object,
     authentication: PropTypes.object,
     dispatch: PropTypes.func,
     history: PropTypes.object
@@ -92,9 +93,9 @@ class Reader extends Component {
         <style key={index}>
           {stylesheet.attributes.styles}
         </style>
-      )
-    })
-  }
+      );
+    });
+  };
 
   render() {
     const text = this.props.text;
@@ -103,6 +104,7 @@ class Reader extends Component {
         <div>
           {this.renderStyles()}
           <DocumentMeta {...config.app}/>
+          <LoadingBar />
           <Header
               text={text}
               authenticated={this.props.authentication.authToken === null ? false : true}

--- a/client/src/theme/Components/_loading-bar.scss
+++ b/client/src/theme/Components/_loading-bar.scss
@@ -1,0 +1,28 @@
+.loading-bar {
+  width: 100%;
+  height: 5px;
+  visibility: hidden;
+  &.loading, &.complete {
+    visibility: visible;
+  }
+  .progress {
+    height: 100%;
+    width: 0%;
+    opacity: 0;
+    background-color: $accentPrimary;
+    position: relative;
+  }
+  &.loading .progress {
+    width: 90%;
+    opacity: 1;
+    transition: width 200s cubic-bezier(.06,.95,.40,.93);
+  }
+  &.complete .progress {
+    width: 100%;
+    opacity: 0;
+    transition: width .7s ease-out, opacity 1.2s ease;
+  }
+  // NB: This can be scoped to a wrapper class if this is used in multiple contexts
+  position: fixed;
+  top: 0;
+}

--- a/client/src/theme/_components.scss
+++ b/client/src/theme/_components.scss
@@ -3,6 +3,7 @@
 
 @import "Components/base";
 @import "Components/shared";
+@import "Components/loading-bar";
 @import "Components/header-browse";
 @import "Components/footer-browse";
 @import "Components/grid-project";

--- a/client/src/theme/_z-stack.scss
+++ b/client/src/theme/_z-stack.scss
@@ -3,10 +3,15 @@
 
 // Z-Indeces for all top level components, all in one place, all in order
 
-.header-browse {
-  z-index: 200;
+.loading-bar {
+  z-index: 600;
 }
 
 .overlay-login {
   z-index: 500;
 }
+
+.header-browse {
+  z-index: 200;
+}
+


### PR DESCRIPTION
[FEATURE DELIVERS #109480056] A global loading indicator component has
been added to both the browse and reader containers. This component is
currently a static element but has all of the markup/style necessary to
work as a global loading indicator bar.
This commit also corrects some minor linter errors in Reader.js

The loading indicator has three states:
Default:
Invoked on load
The indicator is invisible and cannot receive pointer events

Loading:
Invoked by adding ".loading" class to the loading-bar <div>
The indicator is visible and fills first quickly, and then increasingly
slowly as it approaches 90 percent full

Complete:
Invoked by adding ".complete" class to the loading-bar <div>
The indicator quickly fills to full from its previous state, while
simultaneously vanishing with a transition that completes half a second
after it is full

After completion, the bar currently needs to be switched to the default
state before loading/completion again. If this is even slightly
cumbersome to do in React, CSS animations can be employed
(instead of transitions) to reset the animation state for at the
"progress" stage.
